### PR TITLE
feat: add Docker support for Jekyll site and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use the official Ruby image as a base image
+FROM ruby:3.2
+
+# Set environment variables
+ENV JEKYLL_ENV=production
+
+# Install dependencies
+RUN apt-get update && apt-get install -y build-essential
+
+# Create a directory for the Jekyll site
+RUN mkdir /blaize
+WORKDIR /blaize
+
+# Copy the Gemfile and Gemfile.lock into the Docker image
+COPY Gemfile* ./
+
+# Install the gems specified in the Gemfile
+RUN bundle install
+
+# Copy the rest of the site into the Docker image
+COPY . .
+
+# Build the Jekyll site
+RUN bundle exec jekyll build
+
+# Expose port 4000
+EXPOSE 4000
+
+# Start the Jekyll server
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 Simple marketing website for Blaize.IT technology consulting made with [Jekyll](https://jekyllrb.com) using the [Creative](https://github.com/volny/creative-theme-jekyll) theme for [Github Pages](https://pages.github.com).
 
-## Development
+# Development
 
-Run `bundle exec jekyll serve`
+This is a Jekyll site that can be built and served using Docker. 
+
+## Prerequisites 
+
+- [Docker](https://www.docker.com/get-started) installed on your machine 
+
+### Building the Docker Image 
+
+To build the Docker image for this Jekyll site, run the following command in the root directory of this project (where the *Dockerfile* is located): 
+
+```sh 
+docker build -t blaize .
+```
+
+### Running the Docker Container
+
+After building the Docker image, you can run the container with the following command:
+
+```sh 
+docker run -p 4000:4000 blaize
+```
+
+This will start a Jekyll server inside the Docker container and map port 4000 of the container to port 4000 on your host machine.
+
+Once the container is running, you can access your Jekyll site by navigating to:
+
+```sh 
+http://localhost:4000
+```


### PR DESCRIPTION
### Add Docker Support for Jekyll Site and Update README

#### Description

This pull request introduces Docker support for our Jekyll site and updates the README with instructions on how to build and run the Docker container.

#### Changes
- **Dockerfile**:
  - Created a Dockerfile to build and serve the Jekyll site.
  - The Dockerfile installs necessary dependencies, copies the site files, builds the site, and starts the Jekyll server.
- **README**:
  - Updated the README with detailed instructions on building the Docker image and running the container.
  - Included commands to access the Jekyll site and stop the container.

#### Benefits
- Simplifies the process of building and serving the Jekyll site by using Docker.
- Ensures a consistent environment for running the site across different machines.

#### How to Test
1. Follow the instructions in the updated README to build the Docker image.
2. Run the Docker container and verify that the Jekyll site is accessible at `http://localhost:4000`.

#### Jira Task
Closes INT-21